### PR TITLE
VersionDetailFiles: add dsrna.csv and jbrowse.track fields

### DIFF
--- a/internal/pkg/usecase/version/version.go
+++ b/internal/pkg/usecase/version/version.go
@@ -60,14 +60,16 @@ type FileDetail struct {
 }
 
 // VersionDetailFiles holds the latest uploaded file for each single-file type
-// and all uploaded files for orthology.
+// and all uploaded files for orthology / jbrowse.track.
 type VersionDetailFiles struct {
-	GenomicFNA   *FileDetail  `json:"genomic.fna"`
-	GenomicGFF   *FileDetail  `json:"genomic.gff"`
-	RNAFNA       *FileDetail  `json:"rna.fna"`
-	CDSFNA       *FileDetail  `json:"cds.fna"`
-	ProteinFAA   *FileDetail  `json:"protein.faa"`
-	OrthologyTSV []FileDetail `json:"orthology.tsv"`
+	GenomicFNA    *FileDetail  `json:"genomic.fna"`
+	GenomicGFF    *FileDetail  `json:"genomic.gff"`
+	RNAFNA        *FileDetail  `json:"rna.fna"`
+	CDSFNA        *FileDetail  `json:"cds.fna"`
+	ProteinFAA    *FileDetail  `json:"protein.faa"`
+	DsRNACSV      *FileDetail  `json:"dsrna.csv"`
+	OrthologyTSV  []FileDetail `json:"orthology.tsv"`
+	JBrowseTrack  []FileDetail `json:"jbrowse.track"`
 }
 
 // VersionDetail is the response for GET /versions/{name}/detail.
@@ -201,7 +203,7 @@ func (uc *UseCase) GetVersionDetail(ctx context.Context, name string) (*VersionD
 	detail := VersionDetail{
 		Version:   *v,
 		IsDefault: defaultVersionID != nil && *defaultVersionID == v.ID,
-		Files:     VersionDetailFiles{OrthologyTSV: []FileDetail{}},
+		Files:     VersionDetailFiles{OrthologyTSV: []FileDetail{}, JBrowseTrack: []FileDetail{}},
 	}
 
 	for _, f := range files {
@@ -222,6 +224,8 @@ func (uc *UseCase) GetVersionDetail(ctx context.Context, name string) (*VersionD
 		switch f.FileType {
 		case entity.FileTypeOrthologyTSV:
 			detail.Files.OrthologyTSV = append(detail.Files.OrthologyTSV, fd)
+		case entity.FileTypeJBrowseTrack:
+			detail.Files.JBrowseTrack = append(detail.Files.JBrowseTrack, fd)
 		default:
 			if !seen[f.FileType] {
 				seen[f.FileType] = true
@@ -236,6 +240,8 @@ func (uc *UseCase) GetVersionDetail(ctx context.Context, name string) (*VersionD
 					detail.Files.CDSFNA = &fd
 				case entity.FileTypeProteinFAA:
 					detail.Files.ProteinFAA = &fd
+				case entity.FileTypeDsRNACSV:
+					detail.Files.DsRNACSV = &fd
 				}
 			}
 		}


### PR DESCRIPTION
Adds `dsrna.csv` (single `*FileDetail`) and `jbrowse.track` (array `[]FileDetail`) to the `VersionDetailFiles` struct and the switch statement in `GetVersionDetail` so they appear in the `/api/versions/{name}/detail` response.

Entity constants already exist in `entity/upload_file.go` — this just wires them into the response.