### PR TITLE
fix: return empty results instead of 422 when no default version

### DIFF
--- a/internal/pkg/api/handler/genes.go
+++ b/internal/pkg/api/handler/genes.go
@@ -46,7 +46,7 @@ func (h *GenesHandler) BySpecies(c *gin.Context) {
 			return
 		}
 		if errors.Is(err, ucsearch.ErrNoDefaultVersion) {
-			apires.Fail(c, http.StatusUnprocessableEntity, "no default version configured")
+			apires.OK(c, []ucsearch.GeneDetail{})
 			return
 		}
 		panic(err)

--- a/internal/pkg/api/handler/orthology.go
+++ b/internal/pkg/api/handler/orthology.go
@@ -38,7 +38,7 @@ func (h *OrthologyHandler) BySpecies(c *gin.Context) {
 			return
 		}
 		if errors.Is(err, ucsearch.ErrNoDefaultVersion) {
-			apires.Fail(c, http.StatusUnprocessableEntity, "no default version configured")
+			apires.OK(c, []ucsearch.GeneOrthology{})
 			return
 		}
 		panic(err)

--- a/internal/pkg/api/handler/search.go
+++ b/internal/pkg/api/handler/search.go
@@ -37,7 +37,7 @@ func (h *SearchHandler) Suggest(c *gin.Context) {
 			return
 		}
 		if errors.Is(err, ucsearch.ErrNoDefaultVersion) {
-			apires.Fail(c, http.StatusUnprocessableEntity, "no default version configured")
+			apires.OK(c, []string{})
 			return
 		}
 		panic(err)
@@ -63,7 +63,7 @@ func (h *SearchHandler) Search(c *gin.Context) {
 			return
 		}
 		if errors.Is(err, ucsearch.ErrNoDefaultVersion) {
-			apires.Fail(c, http.StatusUnprocessableEntity, "no default version configured")
+			apires.OK(c, &ucsearch.SearchResult{})
 			return
 		}
 		panic(err)

--- a/internal/pkg/api/handler/silencingseqs.go
+++ b/internal/pkg/api/handler/silencingseqs.go
@@ -43,7 +43,7 @@ func (h *SilencingSeqsHandler) Get(c *gin.Context) {
 			return
 		}
 		if errors.Is(err, ucsearch.ErrNoDefaultVersion) {
-			apires.Fail(c, http.StatusUnprocessableEntity, "no default version configured")
+			apires.OK(c, []ucsearch.SilencingSeq{})
 			return
 		}
 		panic(err)


### PR DESCRIPTION
## Problem

Public endpoints (`/search`, `/search/_suggest`, `/silencingseqs`, `/genes/:species`, `/orthology/:species`) return **422 Unprocessable Entity** with `"no default version configured"` when no version is set.

This was designed for a system where data is always pre-seeded. But now admins upload data — the API returns 422 even for regular users who can't fix it.

## Root Cause

`ErrNoDefaultVersion` was treated as a client error (422). It isn't. The client can't fix it — only an admin uploading data can. Regular users just see a broken website.

## Fix

Each handler now returns an empty successful response instead of an error when `ErrNoDefaultVersion` is encountered:

| Endpoint | Before | After |
|---|---|---|
| `GET /search` | 422 + error | 200 + `{data: {}}` |
| `GET /search/_suggest` | 422 + error | 200 + `[]` |
| `GET /silencingseqs` | 422 + error | 200 + `[]` |
| `GET /genes/:species` | 422 + error | 200 + `[]` |
| `GET /orthology/:species` | 422 + error | 200 + `[]` |

## Other concerns

By removing the 422 error, we've lose the immediate feedback from api that no default version is configured. The frontend should call `GET /versions` on load and display a warning banner when no active version is found, so admin are reminded to upload data or set a default version.
